### PR TITLE
Updated the gunicorn worker to work with gunicorn 19.1

### DIFF
--- a/aiopyramid/gunicorn/worker.py
+++ b/aiopyramid/gunicorn/worker.py
@@ -51,7 +51,7 @@ class AiopyramidHttpServerProtocol(WSGIServerHttpProtocol):
 
 class AsyncGunicornWorker(AiohttpWorker):
 
-    def factory(self, wsgi, host, port):
+    def factory(self, wsgi, addr):
         proto = AiopyramidHttpServerProtocol(
             wsgi, loop=self.loop,
             log=self.log,


### PR DESCRIPTION
The gunicorn commit https://github.com/benoitc/gunicorn/commit/2b2725dddb6e54c3328524e4efa52b544fd77841 changed the signature of the factory method for the gaiohhtp worker to take one parameter `addr` instead of the `host, port` parameters used before. 
This commit updates the aiopyramid code to match that change.
