### PR TITLE
To make POST work

### DIFF
--- a/aiopyramid/gunicorn/worker.py
+++ b/aiopyramid/gunicorn/worker.py
@@ -65,6 +65,7 @@ class AsyncGunicornWorker(AiohttpWorker):
     def factory(self, wsgi, *args):
         proto = AiopyramidHttpServerProtocol(
             wsgi, loop=self.loop,
+            readpayload=True,
             log=self.log,
             keep_alive=self.cfg.keepalive,
             access_log=self.log.access_log,


### PR DESCRIPTION
When defining a POST it broke

Traceback (most recent call last):
  File "/Users/ramon/.buildout/eggs/aiohttp-0.15.3-py3.4-macosx-10.9-x86_64.egg/aiohttp/server.py", line 273, in start
    yield from self.handle_request(message, payload)
  File "/Users/ramon/Development/horus/src/aiopyramid/aiopyramid/gunicorn/worker.py", line 29, in handle_request
    payload.read = synchronize(payload.read)
  File "/Users/ramon/Development/horus/src/aiopyramid/aiopyramid/helpers.py", line 127, in synchronize
    return _wrapper(coroutine_func)
  File "/Users/ramon/Development/horus/src/aiopyramid/aiopyramid/helpers.py", line 93, in _wrapper
    coroutine_func
pyramid.exceptions.ConfigurationError: Attempted to synchronize a non-coroutine <bound method FlowControlStreamReader.read of <aiohttp.streams.FlowControlStreamReader object at 0x10ecce0b8>>.

So adding that adding to read the info on the protocols solves the problem
