### PR TITLE
Do not silently drop uWSGI websocket errors

### DIFF
--- a/aiopyramid/websocket/config/uwsgi.py
+++ b/aiopyramid/websocket/config/uwsgi.py
@@ -81,7 +81,7 @@ class UWSGIWebsocketMapper(AsyncioMapperBase):
             while True:
                 if future.done():
                     if future.exception() is not None:
-                        raise future.exception()
+                        raise WebsocketClosed from future.exception()
                     raise WebsocketClosed
 
                 # message in

--- a/aiopyramid/websocket/config/uwsgi.py
+++ b/aiopyramid/websocket/config/uwsgi.py
@@ -80,6 +80,8 @@ class UWSGIWebsocketMapper(AsyncioMapperBase):
 
             while True:
                 if future.done():
+                    if future.exception() is not None:
+                        raise future.exception()
                     raise WebsocketClosed
 
                 # message in

--- a/aiopyramid/websocket/helpers.py
+++ b/aiopyramid/websocket/helpers.py
@@ -8,6 +8,8 @@ def ignore_websocket_closed(app):
     def _call_app_ignoring_ws_closed(environ, start_response):
         try:
             return app(environ, start_response)
-        except WebsocketClosed:
+        except WebsocketClosed as e:
+            if e.cause:
+                raise
             return ('')
     return _call_app_ignoring_ws_closed

--- a/aiopyramid/websocket/helpers.py
+++ b/aiopyramid/websocket/helpers.py
@@ -9,7 +9,7 @@ def ignore_websocket_closed(app):
         try:
             return app(environ, start_response)
         except WebsocketClosed as e:
-            if e.cause:
+            if e.__cause__:
                 raise
             return ('')
     return _call_app_ignoring_ws_closed


### PR DESCRIPTION
Currently errors in uWSGI websocket views simply closes the socket with WebsocketClosed exception which prevents exceptions from propagating. This PR fixes that.