### PR TITLE
Revised CoroutineOrExecutorMapper

### DIFF
--- a/aiopyramid/websocket/config/gunicorn.py
+++ b/aiopyramid/websocket/config/gunicorn.py
@@ -78,7 +78,8 @@ class SwitchProtocolsResponse(Response):
         http_1_1 = environ['SERVER_PROTOCOL'] == 'HTTP/1.1'
 
         def get_header(k):
-            return environ['HTTP_' + k.upper().replace('-', '_')]
+            key_map = {k.upper(): k for k in environ}
+            return environ[key_map['HTTP_' + k.upper().replace('-', '_')]]
 
         key = websockets.handshake.check_request(get_header)
 


### PR DESCRIPTION
CoroutineOrExecutorMapper should check the Class Based View's request method, not necessarily __call__.