### PR TITLE
fix: Correct aiohttp/aiohttp-wsgi requirements versions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     zip_safe=False,
     install_requires=requires,
     extras_require={
-        'gunicorn': ['gunicorn>=19.1.1', 'aiohttp>=1.0.0', 'aiohttp_wsgi', 'websockets'],
+        'gunicorn': ['gunicorn>=19.1.1', 'aiohttp>=2.0.0', 'aiohttp_wsgi>=0.7.0', 'websockets'],
     },
     license="BSD-derived (http://www.repoze.org/LICENSE.txt)",
     entry_points="""\


### PR DESCRIPTION
* AsyncGunicornWorker's call to aiohttp's `Application.make_handler` fails for `aiohttp<2.0.0`

When aiohttp's `aiohttp.web.Application.make_handler` function makes a call to instantiate the web server, it passes the explicit keyword `loop=` in addition to chained `**kwargs`. In versions of `aiohttp<=1.3.5`, the function signature does not include `loop=` after the single asterisk argument, so the `loop=` keyword arg ends up stuffed into the `kwargs` dict within the scope of the Application's `make_handler` method. 

In effect, when the call to instantiate `Server` is made, the `loop` keyword is being passed explicitly via `loop=` **and** via the `kwargs` keyword, which results in an exception: `TypeError: type object got multiple values for keyword argument 'loop'`.

In `aiohttp>=2.0.0`, the function signature was changed to include `loop=None` **after** the single asterisk arg (`*,`), which effectively drops it from the kwargs dict, preventing the arg from being chained into `Server` via keyword and dict expansion.

This is to aid in any usage of the library that may have already had `aiohttp>=1.0.0` and `aiohttp<2.0.0` installed. Basically; `aiopyramid>=0.3.7` versions don't actually support `aiohttp` versions less than `2.0.0`.