### PR TITLE
Class methods in view mappers and synchronous function call fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@ Changes
 
 .. :changelog:
 
+0.4.2 (2019-06-18)
+------------------
+    - Add class methods support into view mappers
+    - Fix synchronous function call from executor view
+
 0.4.1 (2016-06-04)
 ------------------
     - Fix dependency mismatch for cases of aiohttp > 1.0 but < 2.0

--- a/aiopyramid/config.py
+++ b/aiopyramid/config.py
@@ -59,7 +59,7 @@ class CoroutineMapper(AsyncioMapperBase):
         view = super().__call__(view)
 
         if is_generator(original) or is_generator(
-                getattr(original, '__call__', None)
+            getattr(original, '__call__', None)
         ):
             view = asyncio.coroutine(view)
         elif not asyncio.iscoroutinefunction(original):
@@ -76,7 +76,7 @@ class ExecutorMapper(AsyncioMapperBase):
         if inspect.isclass(view):
             view = getattr(view, self.attr)
         if asyncio.iscoroutinefunction(view) or asyncio.iscoroutinefunction(
-                getattr(view, '__call__', None)
+            getattr(view, '__call__', None)
         ):
             raise ConfigurationError(
                 'Coroutine {} mapped to executor.'.format(view)
@@ -100,11 +100,11 @@ class CoroutineOrExecutorMapper(AsyncioMapperBase):
         view = super().__call__(view)
 
         if (
-                asyncio.iscoroutinefunction(original) or
-                is_generator(original) or
-                is_generator(
-                    getattr(original, '__call__', None)
-                )
+            asyncio.iscoroutinefunction(original) or
+            is_generator(original) or
+            is_generator(
+                getattr(original, '__call__', None)
+            )
         ):
             view = asyncio.coroutine(view)
             return self.run_in_coroutine_view(view)

--- a/aiopyramid/config.py
+++ b/aiopyramid/config.py
@@ -39,27 +39,27 @@ class AsyncioMapperBase(DefaultViewMapper):
             # This must be done in a non-async context
             request.params.__getitem__ = request.params.__getitem__
 
-            try:
-                # since we are running in a new thread,
-                # remove the old wsgi.file_wrapper for uwsgi
-                request.environ.pop('wsgi.file_wrapper')
-            finally:
-                exe = synchronizer(asyncio.get_event_loop().run_in_executor)
-                return exe(None, view, context, request)
+            # since we are running in a new thread,
+            # remove the old wsgi.file_wrapper for uwsgi
+            request.environ.pop('wsgi.file_wrapper', None)
+            exe = synchronizer(asyncio.get_event_loop().run_in_executor)
+            return exe(None, view, context, request)
 
         return executor_view
 
+    def is_class_method_coroutine(self, view):
+        return inspect.isclass(view) and asyncio.iscoroutinefunction(getattr(view, self.attr))
 
 class CoroutineMapper(AsyncioMapperBase):
 
     def __call__(self, view):
-        if inspect.isclass(view):
-            view = getattr(view, self.attr)
         original = view
         view = super().__call__(view)
 
-        if is_generator(original) or is_generator(
-            getattr(original, '__call__', None)
+        if (
+            is_generator(original)
+            or is_generator(getattr(original, '__call__', None))
+            or (self.is_class_method_coroutine(original))
         ):
             view = asyncio.coroutine(view)
         elif not asyncio.iscoroutinefunction(original):
@@ -73,10 +73,10 @@ class CoroutineMapper(AsyncioMapperBase):
 class ExecutorMapper(AsyncioMapperBase):
 
     def __call__(self, view):
-        if inspect.isclass(view):
-            view = getattr(view, self.attr)
-        if asyncio.iscoroutinefunction(view) or asyncio.iscoroutinefunction(
-            getattr(view, '__call__', None)
+        if (
+            asyncio.iscoroutinefunction(view)
+            or asyncio.iscoroutinefunction(getattr(view, '__call__', None))
+            or self.is_class_method_coroutine(view)
         ):
             raise ConfigurationError(
                 'Coroutine {} mapped to executor.'.format(view)
@@ -88,8 +88,6 @@ class ExecutorMapper(AsyncioMapperBase):
 class CoroutineOrExecutorMapper(AsyncioMapperBase):
 
     def __call__(self, view):
-        if inspect.isclass(view):
-            view = getattr(view, self.attr)
         original = view
         while asyncio.iscoroutinefunction(view):
             try:
@@ -100,11 +98,10 @@ class CoroutineOrExecutorMapper(AsyncioMapperBase):
         view = super().__call__(view)
 
         if (
-            asyncio.iscoroutinefunction(original) or
-            is_generator(original) or
-            is_generator(
-                getattr(original, '__call__', None)
-            )
+            asyncio.iscoroutinefunction(original)
+            or is_generator(original)
+            or is_generator(getattr(original, '__call__', None))
+            or self.is_class_method_coroutine(original)
         ):
             view = asyncio.coroutine(view)
             return self.run_in_coroutine_view(view)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if py_version < (3, 4):
 
 setup(
     name='aiopyramid',
-    version='0.4.1',
+    version='0.4.2',
     description='Tools for running pyramid using asyncio.',
     long_description=README + '\n\n\n\n' + CHANGES,
     classifiers=[


### PR DESCRIPTION
Added class methods support into view mappers
Fixed synchronous function call from executor view
