### PR TITLE
docs: Fix a few typos

### DIFF
--- a/aiopyramid/helpers.py
+++ b/aiopyramid/helpers.py
@@ -58,7 +58,7 @@ def spawn_greenlet(func, *args, **kwargs):
 def run_in_greenlet(back, future, func, *args, **kwargs):
     """
     Wait for :term:`coroutine` func and switch back to the request greenlet
-    setting any result in the future or an Exception where approrpiate.
+    setting any result in the future or an Exception where appropriate.
 
     func is often a :term:`view callable`
     """

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -87,7 +87,7 @@ Authentication
 
 Authentication poses a problem because the interface for
 :term:`authentication policies <authentication policy>` uses normal Python methods that the framework expects
-to call noramlly but at the same time it is usually necessary to perform some io to retrieve relevant information.
+to call normally but at the same time it is usually necessary to perform some io to retrieve relevant information.
 The built-in :term:`authentication policies <authentication policy>` generally accept a callback function that
 delegates retrieving :term:`principals <principal>` to the application, but this callback function is also expected
 to be called in the regular fashion. So, it is necessary to use a :term:`synchronized coroutine` as a callback
@@ -353,7 +353,7 @@ uWSGI Special Note
 
 ``Aiopyramid`` uses a special :class:`~aiopyramid.websocket.exceptions.WebsocketClosed` exception
 to disconnect a :term:`greenlet` after a :term:`websocket`
-has been closed. This exception will be visible in log ouput when using `uWSGI`_. In order to squelch this
+has been closed. This exception will be visible in log output when using `uWSGI`_. In order to squelch this
 message, wrap the wsgi application in the :func:`~aiopyramid.websocket.helpers.ignore_websocket_closed` middleware
 in your application's constructor like so:
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -133,7 +133,7 @@ route declared in the app constructor. It also assigns a :term:`renderer` to the
 render the data returned into the ``template/home.jinja`` template and return a response
 to the user. Line 2 wraps the view in a coroutine which differentiates it from a generator
 or native coroutine. Line 3 is the signature for the coroutine. ``Aiopyramid`` view mappers
-do not change the two default signarures for views, i.e. views that accept a request
+do not change the two default signatures for views, i.e. views that accept a request
 and views that accept a context and a request. On line 4, we retrieve a sleep parameter,
 from the request (the parameter can be either part of the querystring or the body). If
 the request doesn't include a sleep parameter, the view defaults to 0.1. We don't need to
@@ -165,7 +165,7 @@ of the view to accept a single websocket connection instead of a request. The co
 for communicating with the :term:`websocket` :meth:`recv`, :meth:`send`, and :meth:`close` that
 correspond to similar methods in the `websockets`_ library.
 
-This websocket view will run echoing the data it recieves until the connection is closed. On line 5 we use
+This websocket view will run echoing the data it receives until the connection is closed. On line 5 we use
 ``yield from`` to wait until a message is received. If the message is None, then we know that the websocket
 has closed and we break the loop to complete the echo coroutine. Otherwise, line 7 simply returns the same
 message back to the websocket. Very simple. In both cases when we need to perform some io we use ``yield from``
@@ -210,7 +210,7 @@ The ``port`` setting here is the port that we will use to access the application
 Setup
 .....
 
-The ``setup.py`` file makes the ``aiotutorial`` package easy to distirbute, and it is also a good way, although
+The ``setup.py`` file makes the ``aiotutorial`` package easy to distribute, and it is also a good way, although
 not the only good way, to manage dependencies for our project. Lines 18-21 list the Python packages that we need
 for this project.
 
@@ -283,7 +283,7 @@ limitations) and go to http://127.0.0.1:6543?sleep=10. The new browser should ta
 to load the page because our view is waiting for the value of ``sleep``. However, while that request is
 ongoing, you can refresh your first browser and see that the server is still able to fulfill requests.
 
-Congratulations! You have successfuly setup a highly configurable asynchronous server using ``Aiopyramid``!
+Congratulations! You have successfully setup a highly configurable asynchronous server using ``Aiopyramid``!
 
 .. note:: *Extra Credit*
 


### PR DESCRIPTION
There are small typos in:
- aiopyramid/helpers.py
- docs/features.rst
- docs/tutorial.rst

Fixes:
- Should read `successfully` rather than `successfuly`.
- Should read `signatures` rather than `signarures`.
- Should read `receives` rather than `recieves`.
- Should read `output` rather than `ouput`.
- Should read `normally` rather than `noramlly`.
- Should read `distribute` rather than `distirbute`.
- Should read `appropriate` rather than `approrpiate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md